### PR TITLE
Bump `coloraide` to 4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "coloraide" %}
-{% set version = "4.1" %}
-{% set sha256 = "8c57823227ba941f60a2d59b46cc023d6d3e4c6ae065117e40717391569e9f7d" %}
-{% set build_number = 1 %}
+{% set version = "4.2" %}
+{% set sha256 = "ee4a0968f3356348067e13841dab64a106052eba00ff947ce751ba944e51a6a3" %}
+{% set build_number = 0 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This PR updates `coloraide` to version 4.2.

Would it be possible to add me as a maintainer of this feedstock? I use this library quite frequently, so I'd be interested in helping maintaining it here.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
